### PR TITLE
Use ocamlbuild, add merlin support

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,4 @@
+S .
+B _build
+
+PKG ANSITerminal

--- a/_tags
+++ b/_tags
@@ -1,0 +1,1 @@
+true: package(ANSITerminal)

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-cs3110 compile -p ANSITerminal bouncr.ml &&
-cs3110 run bouncr.ml
+ocamlbuild -use-ocamlfind bouncr.native
+./bouncr.native


### PR DESCRIPTION
These commits modify run.sh to use ocamlbuild instead of badly written tools, and also add a config for the [merlin](https://github.com/the-lambda-church/merlin) plugin for Vim and Emacs.
